### PR TITLE
Bug fix

### DIFF
--- a/app/src/main/java/frogermcs/io/likeanimation/LikeButtonView.java
+++ b/app/src/main/java/frogermcs/io/likeanimation/LikeButtonView.java
@@ -155,6 +155,12 @@ public class LikeButtonView extends FrameLayout implements View.OnClickListener 
                     setPressed(false);
                 }
                 break;
+                
+            case MotionEvent.ACTION_CANCEL:
+                ivStar.animate().scaleX(1).scaleY(1).setInterpolator(DECCELERATE_INTERPOLATOR);
+                setPressed(false);
+                break;
+
         }
         return true;
     }


### PR DESCRIPTION
When this view was in a scroll view. If Action_Down occurs on view and then if users swipes, scrollView observes the Touch. In that case we should not retain pressed state. But View is still in pressed and scale down.

So if this view is in a scroll view. When users scrolls touching this view. The view retains the pressed and scale down state.

This commit fixes that
